### PR TITLE
Fix django logging.

### DIFF
--- a/src/backend/backend/settings.py
+++ b/src/backend/backend/settings.py
@@ -132,10 +132,8 @@ LOGGING = {
     "loggers": {
         "django": {
             "handlers": ["console", "file"],
-            "level": LOG_LEVEL,
         },
         "api": {
-            "level": LOG_LEVEL,
             "handlers": ["console", "file"],
         },
     },

--- a/src/backend/backend/settings.py
+++ b/src/backend/backend/settings.py
@@ -130,9 +130,13 @@ LOGGING = {
         },
     },
     "loggers": {
-        "": {
+        "django": {
             "handlers": ["console", "file"],
-            "propagate": True,
+            "level": LOG_LEVEL,
+        },
+        "api": {
+            "level": LOG_LEVEL,
+            "handlers": ["console", "file"],
         },
     },
 }


### PR DESCRIPTION
Исправление настроек логирования, теперь логируются как логи Django по умолчанию, так и логи из приложения api.
Пример записи логов в приложении
```Python
import logging

_LOGGER = logging.getLogger(__name__)

_LOGGER.error("Ужасная ошибка :с")
```