### PR TITLE
chore(ci): update GitHub Actions versions and fix Django settings

### DIFF
--- a/.github/workflows/ci_lint_tests.yml
+++ b/.github/workflows/ci_lint_tests.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     -
       name: Check out the repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     -
       name: Setup Poetry
       uses: Gr1N/setup-poetry@v9
@@ -21,7 +21,7 @@ jobs:
         poetry-version: "1.8.2"
     -
       name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
     -
@@ -44,7 +44,7 @@ jobs:
     steps:
     -
       name: Check out the repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     -
       name: Setup Poetry
       uses: Gr1N/setup-poetry@v9
@@ -52,7 +52,7 @@ jobs:
         poetry-version: "1.8.2"
     -
       name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
     -

--- a/.github/workflows/deploy_workflow_prod.yml
+++ b/.github/workflows/deploy_workflow_prod.yml
@@ -30,7 +30,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: master
       - name: GitHub Packages login
@@ -40,7 +40,7 @@ jobs:
           GITHUB: ${{ env.REGISTRY }}
         run: echo "$GITHUB_TOKEN" | docker login "${GITHUB}" -u "${USERNAME}" --password-stdin
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile
@@ -56,12 +56,12 @@ jobs:
     needs: build-and-push-image-to-github-packages
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: master
 
       - name: Copy docker compose file to server
-        uses: appleboy/scp-action@master
+        uses: appleboy/scp-action@v1.0.0
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.SSH_USER }}
@@ -70,7 +70,7 @@ jobs:
           target: ${{ env.DEPLOY_PATH }}
 
       - name: Executing remote ssh commands to deploy
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.SSH_USER }}

--- a/src/backend/backend/settings.py
+++ b/src/backend/backend/settings.py
@@ -7,9 +7,12 @@ load_dotenv()
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = os.getenv("SECRET_KEY", default="secret_key")
-DEBUG = os.getenv("DEBUG", default=False)
+DEBUG = os.getenv("DEBUG", default="False").lower() in ("true", "1", "yes")
 
-ALLOWED_HOSTS = [os.getenv("ALLOWED_HOSTS", default="*")]
+ALLOWED_HOSTS = [
+    host.strip()
+    for host in os.getenv("ALLOWED_HOSTS", default="*").split(",")
+]
 DOMAIN = os.getenv("DOMAIN", default="127.0.0.1")
 TOKEN = os.getenv("TOKEN")
 SOCKS5_PROXY_URL = os.getenv("SOCKS5_PROXY_URL")


### PR DESCRIPTION
## Summary
- Update GitHub Actions to latest versions to resolve Node.js 20 deprecation warning:
  - `actions/checkout` v4 → v6
  - `actions/setup-python` v5 → v6
  - `docker/build-push-action` v5 → v7
  - `appleboy/scp-action` @master → v1.0.0
  - `appleboy/ssh-action` @master → v1.2.5
- Fix `DEBUG` parsing: `os.getenv` returns a string, so `"False"` was truthy — now correctly parsed as boolean
- Fix `ALLOWED_HOSTS`: now supports comma-separated values (e.g. `127.0.0.1,bot.youcan.by`)

## Test plan
- [ ] Verify CI workflow runs successfully with updated action versions
- [ ] Confirm `DEBUG=False` disables Django debug mode on prod
- [ ] Confirm `ALLOWED_HOSTS` with comma-separated hosts works correctly
- [ ] Verify `bot.youcan.by` no longer returns `DisallowedHost` error