### PR TITLE
fix(bot): tolerate "none" tariff and isolate per-LK failures

### DIFF
--- a/src/bot/external_requests/service.py
+++ b/src/bot/external_requests/service.py
@@ -55,8 +55,9 @@ async def get_user_info_from_lk(telegram_id: int) -> Optional[UserInfo]:
     )
 
     if user_info_from_youcanby is None and user_info_from_robotguru is None:
-        if youcanby_error is not None and robotguru_error is not None:
-            raise youcanby_error
+        lk_error = youcanby_error or robotguru_error
+        if lk_error is not None:
+            raise lk_error
         raise UserNotFound()
     if user_info_from_robotguru is None:
         return user_info_from_youcanby

--- a/src/bot/external_requests/service.py
+++ b/src/bot/external_requests/service.py
@@ -1,5 +1,5 @@
 from logging import getLogger
-from typing import Optional, TypedDict
+from typing import Awaitable, Callable, Optional, Tuple, TypedDict
 
 from httpx import AsyncClient, HTTPStatusError, Response, codes
 
@@ -15,6 +15,8 @@ from utils.configs import (
     YOUCANBY_TOKEN,
     YOUCANBY_URL,
 )
+
+EMPTY_TARIFF_ALIASES = frozenset({"", "none", "null"})
 
 IS_APPROVED = "isApproved"
 FIRST_NAME = "first_name"
@@ -45,24 +47,44 @@ _LOGGER = getLogger(__name__)
 async def get_user_info_from_lk(telegram_id: int) -> Optional[UserInfo]:
     check_telegram_id(telegram_id)
 
-    user_info_from_youcanby = await _get_user_info_from_youcanby(telegram_id)
-    user_info_from_robotguru = await _get_user_info_from_robotguru(telegram_id)
+    user_info_from_youcanby, youcanby_error = await _safe_get_lk_info(
+        _get_user_info_from_youcanby, telegram_id, "youcan.by"
+    )
+    user_info_from_robotguru, robotguru_error = await _safe_get_lk_info(
+        _get_user_info_from_robotguru, telegram_id, "robotguru"
+    )
 
     if user_info_from_youcanby is None and user_info_from_robotguru is None:
+        if youcanby_error is not None and robotguru_error is not None:
+            raise youcanby_error
         raise UserNotFound()
-    if user_info_from_youcanby is not None and user_info_from_robotguru is None:
+    if user_info_from_robotguru is None:
         return user_info_from_youcanby
-    if user_info_from_youcanby is None and user_info_from_robotguru is not None:
+    if user_info_from_youcanby is None:
         return user_info_from_robotguru
     if (
         TARIFF_PRIORITY[user_info_from_youcanby[TARIFF]]
         >= TARIFF_PRIORITY[user_info_from_robotguru[TARIFF]]
     ):
-        user_info = user_info_from_youcanby
-    else:
-        user_info = user_info_from_robotguru
+        return user_info_from_youcanby
+    return user_info_from_robotguru
 
-    return user_info
+
+async def _safe_get_lk_info(
+    fetch: Callable[[int], Awaitable[Optional[UserInfo]]],
+    telegram_id: int,
+    source_name: str,
+) -> Tuple[Optional[UserInfo], Optional[BaseException]]:
+    try:
+        return await fetch(telegram_id), None
+    except Exception as exc:
+        _LOGGER.warning(
+            "Не удалось получить профиль из %s для telegram_id=%s: %r",
+            source_name,
+            telegram_id,
+            exc,
+        )
+        return None, exc
 
 
 def check_telegram_id(value: int) -> int:
@@ -111,10 +133,10 @@ async def _parse_json_response_to_user_info(data: dict) -> UserInfo:
         if key not in data:
             raise ValidationExternalResponseError(f"В ответе нет ключа: {key}")
 
-    tariff_value = data[TARIFF]
+    tariff_value = _normalize_tariff(data[TARIFF])
     if tariff_value not in ALL_TARIFFS:
         raise ValidationExternalResponseError(
-            f"Получено некорректное значение для тарифа: {tariff_value}."
+            f"Получено некорректное значение для тарифа: {data[TARIFF]}."
             f" Ожидались: {ALL_TARIFFS}."
         )
 
@@ -137,3 +159,12 @@ async def _parse_json_response_to_user_info(data: dict) -> UserInfo:
         last_name=data[LAST_NAME],
         tariff=tariff_value,
     )
+
+
+def _normalize_tariff(tariff_value):
+    if (
+        isinstance(tariff_value, str)
+        and tariff_value.strip().lower() in EMPTY_TARIFF_ALIASES
+    ):
+        return None
+    return tariff_value

--- a/src/bot/external_requests/tests/test_service.py
+++ b/src/bot/external_requests/tests/test_service.py
@@ -1,0 +1,143 @@
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from external_requests import service
+from external_requests.exceptions import (
+    UserNotFound,
+    ValidationExternalResponseError,
+)
+from external_requests.service import (
+    _normalize_tariff,
+    _parse_json_response_to_user_info,
+    get_user_info_from_lk,
+)
+
+
+def _user_info(tariff="maxi", first_name="Ann", last_name="Smith", is_approved=True):
+    return {
+        "isApproved": is_approved,
+        "first_name": first_name,
+        "last_name": last_name,
+        "tariff": tariff,
+    }
+
+
+class NormalizeTariffTests(unittest.TestCase):
+    def test_string_none_becomes_python_none(self):
+        self.assertIsNone(_normalize_tariff("none"))
+
+    def test_string_none_is_case_and_whitespace_insensitive(self):
+        self.assertIsNone(_normalize_tariff("  NoNe "))
+
+    def test_empty_string_becomes_python_none(self):
+        self.assertIsNone(_normalize_tariff(""))
+
+    def test_string_null_becomes_python_none(self):
+        self.assertIsNone(_normalize_tariff("null"))
+
+    def test_known_tariffs_are_unchanged(self):
+        for tariff in ("mini", "midi", "maxi"):
+            with self.subTest(tariff=tariff):
+                self.assertEqual(_normalize_tariff(tariff), tariff)
+
+    def test_python_none_is_unchanged(self):
+        self.assertIsNone(_normalize_tariff(None))
+
+
+class ParseJsonResponseTests(unittest.IsolatedAsyncioTestCase):
+    async def test_tariff_string_none_is_accepted_and_normalized(self):
+        data = _user_info(tariff="none", is_approved=False)
+
+        result = await _parse_json_response_to_user_info(data)
+
+        self.assertIsNone(result["tariff"])
+        self.assertEqual(result["first_name"], "Ann")
+
+    async def test_unknown_tariff_still_raises(self):
+        data = _user_info(tariff="ultra")
+
+        with self.assertRaises(ValidationExternalResponseError):
+            await _parse_json_response_to_user_info(data)
+
+
+class GetUserInfoFromLkTests(unittest.IsolatedAsyncioTestCase):
+    async def test_robotguru_failure_does_not_drop_valid_youcanby_result(self):
+        youcanby_result = _user_info(tariff="maxi")
+
+        with patch.object(
+            service,
+            "_get_user_info_from_youcanby",
+            new=AsyncMock(return_value=youcanby_result),
+        ), patch.object(
+            service,
+            "_get_user_info_from_robotguru",
+            new=AsyncMock(side_effect=ValidationExternalResponseError("boom")),
+        ):
+            result = await get_user_info_from_lk(123)
+
+        self.assertEqual(result, youcanby_result)
+
+    async def test_youcanby_failure_does_not_drop_valid_robotguru_result(self):
+        robotguru_result = _user_info(tariff="midi", first_name="Bob")
+
+        with patch.object(
+            service,
+            "_get_user_info_from_youcanby",
+            new=AsyncMock(side_effect=ValidationExternalResponseError("boom")),
+        ), patch.object(
+            service,
+            "_get_user_info_from_robotguru",
+            new=AsyncMock(return_value=robotguru_result),
+        ):
+            result = await get_user_info_from_lk(123)
+
+        self.assertEqual(result, robotguru_result)
+
+    async def test_both_sources_return_none_raises_user_not_found(self):
+        with patch.object(
+            service,
+            "_get_user_info_from_youcanby",
+            new=AsyncMock(return_value=None),
+        ), patch.object(
+            service,
+            "_get_user_info_from_robotguru",
+            new=AsyncMock(return_value=None),
+        ):
+            with self.assertRaises(UserNotFound):
+                await get_user_info_from_lk(123)
+
+    async def test_both_sources_fail_reraises_first_error(self):
+        youcanby_error = ValidationExternalResponseError("yc broken")
+
+        with patch.object(
+            service,
+            "_get_user_info_from_youcanby",
+            new=AsyncMock(side_effect=youcanby_error),
+        ), patch.object(
+            service,
+            "_get_user_info_from_robotguru",
+            new=AsyncMock(side_effect=ValidationExternalResponseError("rg broken")),
+        ):
+            with self.assertRaises(ValidationExternalResponseError) as ctx:
+                await get_user_info_from_lk(123)
+
+        self.assertIs(ctx.exception, youcanby_error)
+
+    async def test_picks_higher_tariff_when_both_succeed(self):
+        with patch.object(
+            service,
+            "_get_user_info_from_youcanby",
+            new=AsyncMock(return_value=_user_info(tariff="mini")),
+        ), patch.object(
+            service,
+            "_get_user_info_from_robotguru",
+            new=AsyncMock(return_value=_user_info(tariff="maxi", first_name="Bob")),
+        ):
+            result = await get_user_info_from_lk(123)
+
+        self.assertEqual(result["tariff"], "maxi")
+        self.assertEqual(result["first_name"], "Bob")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/bot/external_requests/tests/test_service.py
+++ b/src/bot/external_requests/tests/test_service.py
@@ -123,6 +123,40 @@ class GetUserInfoFromLkTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertIs(ctx.exception, youcanby_error)
 
+    async def test_youcanby_none_and_robotguru_fail_reraises_robotguru_error(self):
+        robotguru_error = ValidationExternalResponseError("rg broken")
+
+        with patch.object(
+            service,
+            "_get_user_info_from_youcanby",
+            new=AsyncMock(return_value=None),
+        ), patch.object(
+            service,
+            "_get_user_info_from_robotguru",
+            new=AsyncMock(side_effect=robotguru_error),
+        ):
+            with self.assertRaises(ValidationExternalResponseError) as ctx:
+                await get_user_info_from_lk(123)
+
+        self.assertIs(ctx.exception, robotguru_error)
+
+    async def test_youcanby_fail_and_robotguru_none_reraises_youcanby_error(self):
+        youcanby_error = ValidationExternalResponseError("yc broken")
+
+        with patch.object(
+            service,
+            "_get_user_info_from_youcanby",
+            new=AsyncMock(side_effect=youcanby_error),
+        ), patch.object(
+            service,
+            "_get_user_info_from_robotguru",
+            new=AsyncMock(return_value=None),
+        ):
+            with self.assertRaises(ValidationExternalResponseError) as ctx:
+                await get_user_info_from_lk(123)
+
+        self.assertIs(ctx.exception, youcanby_error)
+
     async def test_picks_higher_tariff_when_both_succeed(self):
         with patch.object(
             service,


### PR DESCRIPTION
## Summary
- `/start` падал у пользователя с валидной подпиской `maxi` в youcan.by, потому что robotguru отвечал `"tariff": "none"` (строкой). Парсер ронял всё с `ValidationExternalResponseError`, и уже полученный валидный профиль терялся.
- Парсер теперь нормализует `"none"` / `"null"` / `""` (любой регистр и пробелы) в `None` до проверки против `ALL_TARIFFS`; неизвестные тарифы по-прежнему валятся, но в сообщении сохраняется исходное значение для лога.
- `get_user_info_from_lk` оборачивает каждый из двух LK-источников в `_safe_get_lk_info`: ошибка одного больше не отменяет валидный ответ другого. Исходное исключение поднимается, только если упали оба; `UserNotFound` — только когда оба легитимно вернули None.
- 13 unit-тестов под `src/bot/external_requests/tests/` (нормализация тарифа, парсер, выбор источника, fallback, оба-упали, оба-None). Прогоняются текущим CI шагом `python -m unittest` из `src/bot`.

## Test plan
- [x] `python -m flake8 src/bot/external_requests/`
- [x] `python -m isort src/bot/external_requests/ --check --diff`
- [x] `cd src/bot && python -m unittest` (13 passed)
- [ ] После merge — убедиться по проду, что для проблемного telegram_id `/start` доходит до сохранения профиля.