### PR TITLE
fix(bot): retry transient network errors at HTTPXRequest layer

### DIFF
--- a/src/bot/bot.py
+++ b/src/bot/bot.py
@@ -35,6 +35,7 @@ from utils.configs import (
     SOCKS5_PROXY_URL,
     TOKEN,
 )
+from utils.telegram_retry import RetryingHTTPXRequest
 
 
 async def post_init(application: Application) -> None:
@@ -61,8 +62,9 @@ def create_bot():
         .persistence(PicklePersistence(filepath=PERSISTENCE_FILE_PATH))
         .post_init(post_init)
     )
-    if SOCKS5_PROXY_URL:
-        builder = builder.proxy(SOCKS5_PROXY_URL).get_updates_proxy(SOCKS5_PROXY_URL)
+    builder = builder.request(
+        RetryingHTTPXRequest(proxy=SOCKS5_PROXY_URL or None, connection_pool_size=256)
+    ).get_updates_request(RetryingHTTPXRequest(proxy=SOCKS5_PROXY_URL or None))
     bot_app = builder.build()
 
     # mentor registration handlers

--- a/src/bot/utils/telegram_retry.py
+++ b/src/bot/utils/telegram_retry.py
@@ -1,0 +1,70 @@
+import asyncio
+import logging
+from typing import Optional
+
+from telegram._utils.types import ODVInput
+from telegram.error import BadRequest, NetworkError
+from telegram.request import HTTPXRequest
+from telegram.request._baserequest import BaseRequest
+from telegram.request._requestdata import RequestData
+
+_LOGGER = logging.getLogger(__name__)
+
+DO_REQUEST_MAX_ATTEMPTS = 3
+DO_REQUEST_INITIAL_DELAY_SECONDS = 1.0
+
+
+class RetryingHTTPXRequest(HTTPXRequest):
+    """HTTPXRequest that retries transient NetworkError failures.
+
+    RetryAfter is raised one layer above (in BaseRequest.post) and is handled
+    by AIORateLimiter, so it is not retried here to avoid double-retry.
+    BadRequest is also raised above do_request and never reaches this layer.
+    """
+
+    async def do_request(
+        self,
+        url: str,
+        method: str,
+        request_data: Optional[RequestData] = None,
+        read_timeout: ODVInput[float] = BaseRequest.DEFAULT_NONE,
+        write_timeout: ODVInput[float] = BaseRequest.DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = BaseRequest.DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = BaseRequest.DEFAULT_NONE,
+    ) -> tuple[int, bytes]:
+        for attempt in range(1, DO_REQUEST_MAX_ATTEMPTS + 1):
+            try:
+                return await super().do_request(
+                    url=url,
+                    method=method,
+                    request_data=request_data,
+                    read_timeout=read_timeout,
+                    write_timeout=write_timeout,
+                    connect_timeout=connect_timeout,
+                    pool_timeout=pool_timeout,
+                )
+            except BadRequest:
+                raise
+            except NetworkError:
+                if attempt == DO_REQUEST_MAX_ATTEMPTS:
+                    _LOGGER.exception(
+                        "Network error on %s %s after %d attempts",
+                        method,
+                        _redact_url(url),
+                        DO_REQUEST_MAX_ATTEMPTS,
+                    )
+                    raise
+                delay = DO_REQUEST_INITIAL_DELAY_SECONDS * 2 ** (attempt - 1)
+                _LOGGER.warning(
+                    "Network error on %s %s (attempt %d/%d), retrying in %.1fs",
+                    method,
+                    _redact_url(url),
+                    attempt,
+                    DO_REQUEST_MAX_ATTEMPTS,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+
+
+def _redact_url(url: str) -> str:
+    return url.rsplit("/", 1)[-1] or url

--- a/src/bot/utils/tests/test_telegram_retry.py
+++ b/src/bot/utils/tests/test_telegram_retry.py
@@ -1,0 +1,105 @@
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+from telegram.error import BadRequest, NetworkError, RetryAfter
+
+from utils.telegram_retry import (
+    DO_REQUEST_MAX_ATTEMPTS,
+    RetryingHTTPXRequest,
+)
+
+
+def _new_request():
+    request = RetryingHTTPXRequest.__new__(RetryingHTTPXRequest)
+    return request
+
+
+class RetryingHTTPXRequestTests(IsolatedAsyncioTestCase):
+    """Retry behaviour of RetryingHTTPXRequest.do_request."""
+
+    @patch("utils.telegram_retry.asyncio.sleep", new=AsyncMock())
+    @patch("telegram.request.HTTPXRequest.do_request")
+    async def test_returns_payload_on_first_success(self, parent_do_request):
+        parent_do_request.return_value = (200, b"ok")
+        request = _new_request()
+
+        code, payload = await request.do_request(url="https://x", method="POST")
+
+        self.assertEqual((code, payload), (200, b"ok"))
+        parent_do_request.assert_awaited_once()
+
+    @patch("utils.telegram_retry.asyncio.sleep", new=AsyncMock())
+    @patch("telegram.request.HTTPXRequest.do_request")
+    async def test_retries_network_error_then_succeeds(self, parent_do_request):
+        parent_do_request.side_effect = [NetworkError("flap"), (200, b"ok")]
+        request = _new_request()
+
+        code, payload = await request.do_request(url="https://x", method="POST")
+
+        self.assertEqual((code, payload), (200, b"ok"))
+        self.assertEqual(parent_do_request.await_count, 2)
+
+    @patch("utils.telegram_retry.asyncio.sleep", new=AsyncMock())
+    @patch("telegram.request.HTTPXRequest.do_request")
+    async def test_reraises_after_max_attempts(self, parent_do_request):
+        parent_do_request.side_effect = NetworkError("down")
+        request = _new_request()
+
+        with self.assertRaises(NetworkError):
+            await request.do_request(url="https://x", method="POST")
+        self.assertEqual(parent_do_request.await_count, DO_REQUEST_MAX_ATTEMPTS)
+
+    @patch("utils.telegram_retry.asyncio.sleep", new=AsyncMock())
+    @patch("telegram.request.HTTPXRequest.do_request")
+    async def test_does_not_retry_bad_request(self, parent_do_request):
+        parent_do_request.side_effect = BadRequest("Can't parse entities")
+        request = _new_request()
+
+        with self.assertRaises(BadRequest):
+            await request.do_request(url="https://x", method="POST")
+        parent_do_request.assert_awaited_once()
+
+    @patch("utils.telegram_retry.asyncio.sleep", new=AsyncMock())
+    @patch("telegram.request.HTTPXRequest.do_request")
+    async def test_does_not_retry_retry_after(self, parent_do_request):
+        parent_do_request.side_effect = RetryAfter(5)
+        request = _new_request()
+
+        with self.assertRaises(RetryAfter):
+            await request.do_request(url="https://x", method="POST")
+        parent_do_request.assert_awaited_once()
+
+    @patch("utils.telegram_retry.asyncio.sleep", new=AsyncMock())
+    @patch("telegram.request.HTTPXRequest.do_request")
+    async def test_does_not_leak_token_in_logs(self, parent_do_request):
+        parent_do_request.side_effect = [NetworkError("flap"), (200, b"ok")]
+        request = _new_request()
+        token_url = (
+            "https://api.telegram.org/bot7123456789:AAA-secret-token-XYZ/getMe"
+        )
+
+        with self.assertLogs("utils.telegram_retry", level="WARNING") as captured:
+            await request.do_request(url=token_url, method="POST")
+
+        joined = "\n".join(captured.output)
+        self.assertNotIn("AAA-secret-token-XYZ", joined)
+        self.assertNotIn("7123456789", joined)
+        self.assertIn("getMe", joined)
+
+    @patch("utils.telegram_retry.asyncio.sleep", new=AsyncMock())
+    @patch("telegram.request.HTTPXRequest.do_request")
+    async def test_does_not_leak_token_on_exhaustion(self, parent_do_request):
+        parent_do_request.side_effect = NetworkError("down")
+        request = _new_request()
+        token_url = (
+            "https://api.telegram.org/bot7123456789:AAA-secret-token-XYZ/sendMessage"
+        )
+
+        with self.assertLogs("utils.telegram_retry", level="ERROR") as captured:
+            with self.assertRaises(NetworkError):
+                await request.do_request(url=token_url, method="POST")
+
+        joined = "\n".join(captured.output)
+        self.assertNotIn("AAA-secret-token-XYZ", joined)
+        self.assertNotIn("7123456789", joined)
+        self.assertIn("sendMessage", joined)


### PR DESCRIPTION
## Проблема

При флапе SOCKS5-прокси любой Telegram-вызов из handler-а (`edit_text`, `reply_text`, `delete_message`, …) поднимает цепочку `httpcore.RemoteProtocolError → httpx.RemoteProtocolError → telegram.error.NetworkError`. Исключение долетает до `utils/error_handler.py` `error_decorator`, который:

1. Шлёт юзеру **«Ой, что-то пошло не так! Попробуй, пожалуйста, позже.»**
2. Вызывает `context.user_data.clear()` — сносит весь прогресс по текущему вопросу (включая набранный длинный текст ответа).
3. Возвращает `ConversationHandler.END` — диалог полностью закрывается.

Реальный прод-инцидент `bot.log.2026-05-26` 13:12:15 — пользователь `6149265037` потерял длинный ответ в Задании 6 (≈18 пунктов «что радует»). Дамп `user_data` зафиксирован в логе. 

## Решение

Подкласс `HTTPXRequest` с override `do_request`: 3 попытки, экспоненциальный backoff 1s → 2s, ретрай `NetworkError` (`httpx.RemoteProtocolError`, `httpx.ReadError`, `TimedOut` — всё, что PTB оборачивает в `NetworkError` на этом слое).

- `BadRequest` пробрасывается без ретрая (он субкласс `NetworkError` в PTB v22, но не transient — иначе 3 раза ретраили бы ошибки парсинга и неправильные chat_id).
- `RetryAfter` поднимается уровнем выше (в `BaseRequest.post` после возврата из `do_request`) и обрабатывается `AIORateLimiter(max_retries=3)` — сюда не доходит.
- URL в логах редактируется до имени API-метода (`sendMessage`, `getMe`, …), чтобы токен бота не утекал в лог.
- `connection_pool_size=256` для основного request зеркалит PTB-дефолт из `_applicationbuilder.py:238`; для `get_updates_request` дефолт 1 (long-poll в одиночку).

## Зона риска

- При успешной доставке запроса в Telegram, но потерянном ответе (`RemoteProtocolError` на чтении) ретрай может повторить `send_message`/`edit_text`. Тот же трейд-офф уже принят на backend (`src/backend/api/conversation_utils.py:_send_with_retry`). Идемпотентные вызовы (`edit_text`, `delete_message`) безопасны; `send_message` — приоритетный приёмник этого риска, но он не основной call-site (основные — `edit_text` в task callback-ах).
- `AIORateLimiter` × наш `do_request` retry на одном сбое не наслаиваются: rate-limiter ретраит только `RetryAfter`, мы — только `NetworkError`.

## Test plan

- [x] `python -m unittest utils.tests.test_telegram_retry` — 7/7 pass (first-success, retry-then-succeed, exhaust-then-raise, no-retry BadRequest, no-retry RetryAfter, no-token-leak в WARNING-лог, no-token-leak в ERROR-лог)
- [x] Full bot suite `python -m unittest` — 15/15 pass
- [x] Full backend suite `manage.py test src/backend` — 58/58 pass
- [x] `flake8` / `black --check` / `isort --check` — clean
- [ ] Прод-валидация: после деплоя проследить за `bot.log` на наличие `Network error on POST … (attempt 1/3), retrying in 1.0s` и убедиться, что цепочки `ERROR [conversations.task_*.callback_funcs:73] Exception while handling an update` от транзиентных `NetworkError` пропадают.