### PR TITLE
fix(bot): make internal API requests resilient to transient backend slowness

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -912,4 +912,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "b356fba98b43f3d3050fdb4c62eda67e214572cd42df62d00eec878ef0d1cf38"
+content-hash = "09f76f114f874c7d3d120e14b25315aa7d4c9ead996b75035d37fffd3b8ae42d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ pillow = "^11.2.1"
 python-dotenv = "^1.1.0"
 python-slugify = "^8.0.4"
 django-tinymce = "^4.1.0"
+httpx = "^0.28.1"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^4.2.0"

--- a/src/bot/internal_requests/service.py
+++ b/src/bot/internal_requests/service.py
@@ -99,11 +99,14 @@ async def get_info_about_user(telegram_id: int) -> UserFromTelegram:
 
 
 async def update_user_info(telegram_id: int, data: dict):
+    """Обновление информации о пользователе.
+
+    PATCH-эндпоинт идемпотентен: DRF partial_update присваивает поля
+    (name/surname) существующей записи без счётчиков и побочных эффектов
+    (см. backend api/views/users.py), поэтому он помечен idempotent=True
+    и безопасен для повтора того же payload.
+    """
     endpoint_run = f"users/{telegram_id}/"
-    # The user PATCH endpoint is idempotent: it assigns the same fields
-    # (name/surname) on the existing row via DRF's partial_update, with no
-    # counters or side effects (see backend api/views/users.py and
-    # UserFromTelegramUpdateSerializer), so retrying the same payload is safe.
     response = await _patch_request(data, endpoint_run, idempotent=True)
     user_info_updated = await _parse_api_response_to_user_info(response)
     return user_info_updated
@@ -185,22 +188,26 @@ async def delete_mentor(telegram_id: int) -> Response:
 
 
 async def create_question_from_user(problem: Problem) -> Response:
-    """Запрос на занесение вопроса от пользователя в БД."""
+    """Запрос на занесение вопроса от пользователя в БД.
+
+    Эндпоинт problems/ НЕ идемпотентен: на каждый вызов он создаёт новую
+    запись Problem и шлёт уведомление ментору (см. backend
+    api/views/problems.py), поэтому этот POST не повторяется.
+    """
     data = asdict(problem)
     endpoint_urn = f"users/{problem.telegram_id}/problems/"
-    # The problems endpoint is NOT idempotent: it creates a new Problem row and
-    # notifies the mentor on every call (see backend api/views/problems.py), so
-    # this POST must not be retried.
     response = await _post_request(data, endpoint_urn)
     return response
 
 
 async def create_answer(answer: Answer) -> Response:
-    """Запрос на занесение ответа от пользователя на вопрос задания."""
+    """Запрос на занесение ответа от пользователя на вопрос задания.
+
+    Эндпоинт answers/ идемпотентен: существующий ответ на тот же вопрос
+    обновляется, а не дублируется (см. backend api/views/answer.py),
+    поэтому он помечен idempotent=True и безопасен для повтора.
+    """
     endpoint_urn = f"users/{answer.telegram_id}/tasks/{answer.task_number}/answers/"
-    # The answers endpoint is idempotent: it checks for an existing answer to
-    # the same question and updates it instead of creating a duplicate
-    # (see backend api/views/answer.py), so retrying a POST is safe.
     response = await _post_request(
         {"number": answer.number, "content": answer.content},
         endpoint_urn,

--- a/src/bot/internal_requests/service.py
+++ b/src/bot/internal_requests/service.py
@@ -1,9 +1,11 @@
+import asyncio
 import logging
 import os
 from dataclasses import asdict
-from typing import List, Type, TypeVar, Union
+from typing import List, Optional, Type, TypeVar, Union
 from urllib.parse import urljoin
 
+import httpx
 from httpx import AsyncClient, Response
 
 from internal_requests.entities import (
@@ -23,6 +25,49 @@ _LOGGER = logging.getLogger(__name__)
 Model = TypeVar("Model")
 
 INTERNAL_API_URL = os.getenv("INTERNAL_API_URL", "http://127.0.0.1:8000/api/v1/")
+DEFAULT_READ_TIMEOUT_SECONDS = 15.0
+
+REQUEST_MAX_ATTEMPTS = 3
+REQUEST_INITIAL_DELAY_SECONDS = 1.0
+
+
+def _read_timeout_from_env() -> float:
+    """Read INTERNAL_API_TIMEOUT, falling back to the default on bad values."""
+    raw_value = os.getenv("INTERNAL_API_TIMEOUT")
+    if raw_value is None:
+        return DEFAULT_READ_TIMEOUT_SECONDS
+    try:
+        return float(raw_value)
+    except ValueError:
+        _LOGGER.warning(
+            "Ignoring invalid INTERNAL_API_TIMEOUT=%r, using default %.1fs",
+            raw_value,
+            DEFAULT_READ_TIMEOUT_SECONDS,
+        )
+        return DEFAULT_READ_TIMEOUT_SECONDS
+
+
+INTERNAL_API_READ_TIMEOUT = _read_timeout_from_env()
+
+_TIMEOUT = httpx.Timeout(
+    connect=5.0, read=INTERNAL_API_READ_TIMEOUT, write=10.0, pool=5.0
+)
+_LIMITS = httpx.Limits(max_keepalive_connections=10, max_connections=20)
+
+_client: Optional[AsyncClient] = None
+
+
+def _get_client() -> AsyncClient:
+    """Return the shared AsyncClient, creating it lazily on first use.
+
+    No lock is needed: the check and assignment below have no await between
+    them and AsyncClient() is a synchronous constructor, so the asyncio event
+    loop cannot switch tasks mid-initialization and create a second client.
+    """
+    global _client
+    if _client is None:
+        _client = AsyncClient(timeout=_TIMEOUT, limits=_LIMITS)
+    return _client
 
 
 async def get_messages_with_question(
@@ -55,7 +100,11 @@ async def get_info_about_user(telegram_id: int) -> UserFromTelegram:
 
 async def update_user_info(telegram_id: int, data: dict):
     endpoint_run = f"users/{telegram_id}/"
-    response = await _patch_request(data, endpoint_run)
+    # The user PATCH endpoint is idempotent: it assigns the same fields
+    # (name/surname) on the existing row via DRF's partial_update, with no
+    # counters or side effects (see backend api/views/users.py and
+    # UserFromTelegramUpdateSerializer), so retrying the same payload is safe.
+    response = await _patch_request(data, endpoint_run, idempotent=True)
     user_info_updated = await _parse_api_response_to_user_info(response)
     return user_info_updated
 
@@ -139,6 +188,9 @@ async def create_question_from_user(problem: Problem) -> Response:
     """Запрос на занесение вопроса от пользователя в БД."""
     data = asdict(problem)
     endpoint_urn = f"users/{problem.telegram_id}/problems/"
+    # The problems endpoint is NOT idempotent: it creates a new Problem row and
+    # notifies the mentor on every call (see backend api/views/problems.py), so
+    # this POST must not be retried.
     response = await _post_request(data, endpoint_urn)
     return response
 
@@ -146,8 +198,13 @@ async def create_question_from_user(problem: Problem) -> Response:
 async def create_answer(answer: Answer) -> Response:
     """Запрос на занесение ответа от пользователя на вопрос задания."""
     endpoint_urn = f"users/{answer.telegram_id}/tasks/{answer.task_number}/answers/"
+    # The answers endpoint is idempotent: it checks for an existing answer to
+    # the same question and updates it instead of creating a duplicate
+    # (see backend api/views/answer.py), so retrying a POST is safe.
     response = await _post_request(
-        {"number": answer.number, "content": answer.content}, endpoint_urn
+        {"number": answer.number, "content": answer.content},
+        endpoint_urn,
+        idempotent=True,
     )
     return response
 
@@ -161,67 +218,81 @@ async def get_task_8_question(question_number: int, params: List) -> List[Messag
 
 
 async def _get_request_with_params(endpoint_url: str, params) -> Response:
-    async with AsyncClient() as client:
-        response = await client.request(
-            method="GET",
-            url=urljoin(
-                base=INTERNAL_API_URL,
-                url=endpoint_url,
-            ),
-            json=params,
-        )
-    response.raise_for_status()
-    return response
+    return await _request("GET", endpoint_url, json=params, idempotent=True)
 
 
 async def _get_request(endpoint_url: str) -> Response:
-    async with AsyncClient() as client:
-        response = await client.get(
-            url=urljoin(
-                base=INTERNAL_API_URL,
-                url=endpoint_url,
+    return await _request("GET", endpoint_url, idempotent=True)
+
+
+async def _post_request(
+    data: dict, endpoint_url: str, idempotent: bool = False
+) -> Response:
+    return await _request("POST", endpoint_url, json=data, idempotent=idempotent)
+
+
+async def _patch_request(
+    data: dict, endpoint_url: str, idempotent: bool = False
+) -> Response:
+    return await _request("PATCH", endpoint_url, json=data, idempotent=idempotent)
+
+
+async def _delete_request(endpoint_url: str, idempotent: bool = False) -> Response:
+    return await _request("DELETE", endpoint_url, idempotent=idempotent)
+
+
+async def _request(
+    method: str,
+    endpoint_url: str,
+    json=None,
+    idempotent: bool = False,
+) -> Response:
+    """Send a request through the shared client, retrying transient failures.
+
+    Retries are attempted only for safe-to-repeat calls: every GET, and any
+    non-GET method explicitly marked as idempotent. Retryable failures are
+    transport errors (connect/read timeouts, etc.) and 5xx responses; 4xx and
+    successful responses are returned without retry.
+    """
+    url = urljoin(base=INTERNAL_API_URL, url=endpoint_url)
+    for attempt in range(1, REQUEST_MAX_ATTEMPTS + 1):
+        is_last_attempt = attempt == REQUEST_MAX_ATTEMPTS
+        try:
+            response = await _get_client().request(method=method, url=url, json=json)
+        except httpx.TransportError as error:
+            if not idempotent or is_last_attempt:
+                raise
+            await _wait_before_retry(method, endpoint_url, attempt, repr(error))
+            continue
+        if _should_retry_response(response) and idempotent and not is_last_attempt:
+            await _wait_before_retry(
+                method, endpoint_url, attempt, f"status {response.status_code}"
             )
-        )
-    response.raise_for_status()
-    return response
+            continue
+        response.raise_for_status()
+        return response
 
 
-async def _post_request(data: dict, endpoint_url: str) -> Response:
-    async with AsyncClient() as client:
-        response = await client.post(
-            url=urljoin(
-                base=INTERNAL_API_URL,
-                url=endpoint_url,
-            ),
-            json=data,
-        )
-    response.raise_for_status()
-    return response
+def _should_retry_response(response: Response) -> bool:
+    """Return whether the response status code warrants a retry (5xx only)."""
+    return response.status_code >= 500
 
 
-async def _patch_request(data: dict, endpoint_url: str) -> Response:
-    async with AsyncClient() as client:
-        response = await client.patch(
-            url=urljoin(
-                base=INTERNAL_API_URL,
-                url=endpoint_url,
-            ),
-            json=data,
-        )
-    response.raise_for_status()
-    return response
-
-
-async def _delete_request(endpoint_url: str) -> Response:
-    async with AsyncClient() as client:
-        response = await client.delete(
-            url=urljoin(
-                base=INTERNAL_API_URL,
-                url=endpoint_url,
-            )
-        )
-    response.raise_for_status()
-    return response
+async def _wait_before_retry(
+    method: str, endpoint_url: str, attempt: int, reason: str
+) -> None:
+    """Log a warning and sleep with exponential backoff before the next attempt."""
+    delay = REQUEST_INITIAL_DELAY_SECONDS * 2 ** (attempt - 1)
+    _LOGGER.warning(
+        "Transient failure on %s %s (%s), attempt %d/%d, retrying in %.1fs",
+        method,
+        endpoint_url,
+        reason,
+        attempt,
+        REQUEST_MAX_ATTEMPTS,
+        delay,
+    )
+    await asyncio.sleep(delay)
 
 
 async def _parse_api_response_to_messages(response: Response) -> List[Message]:

--- a/src/bot/internal_requests/service.py
+++ b/src/bot/internal_requests/service.py
@@ -32,7 +32,7 @@ REQUEST_INITIAL_DELAY_SECONDS = 1.0
 
 
 def _read_timeout_from_env() -> float:
-    """Read INTERNAL_API_TIMEOUT, falling back to the default on bad values."""
+    """Прочитать INTERNAL_API_TIMEOUT, при некорректном значении взять default."""
     raw_value = os.getenv("INTERNAL_API_TIMEOUT")
     if raw_value is None:
         return DEFAULT_READ_TIMEOUT_SECONDS
@@ -58,11 +58,11 @@ _client: Optional[AsyncClient] = None
 
 
 def _get_client() -> AsyncClient:
-    """Return the shared AsyncClient, creating it lazily on first use.
+    """Вернуть общий AsyncClient, создавая его лениво при первом обращении.
 
-    No lock is needed: the check and assignment below have no await between
-    them and AsyncClient() is a synchronous constructor, so the asyncio event
-    loop cannot switch tasks mid-initialization and create a second client.
+    Lock не нужен: между проверкой `is None` и присваиванием ниже нет await,
+    а конструктор AsyncClient() синхронный, поэтому event loop asyncio не может
+    переключить задачи в середине инициализации и создать второй клиент.
     """
     global _client
     if _client is None:
@@ -254,12 +254,12 @@ async def _request(
     json=None,
     idempotent: bool = False,
 ) -> Response:
-    """Send a request through the shared client, retrying transient failures.
+    """Отправить запрос через общий клиент, повторяя при транзиентных сбоях.
 
-    Retries are attempted only for safe-to-repeat calls: every GET, and any
-    non-GET method explicitly marked as idempotent. Retryable failures are
-    transport errors (connect/read timeouts, etc.) and 5xx responses; 4xx and
-    successful responses are returned without retry.
+    Повтор выполняется только для безопасных для повтора вызовов: всех GET и
+    любых не-GET методов, явно помеченных как idempotent. Повторяемые сбои —
+    это transport-ошибки (таймауты connect/read и т.п.) и 5xx-ответы; 4xx и
+    успешные ответы возвращаются без повтора.
     """
     url = urljoin(base=INTERNAL_API_URL, url=endpoint_url)
     for attempt in range(1, REQUEST_MAX_ATTEMPTS + 1):
@@ -281,14 +281,14 @@ async def _request(
 
 
 def _should_retry_response(response: Response) -> bool:
-    """Return whether the response status code warrants a retry (5xx only)."""
+    """Вернуть, требует ли код статуса ответа повтора (только 5xx)."""
     return response.status_code >= 500
 
 
 async def _wait_before_retry(
     method: str, endpoint_url: str, attempt: int, reason: str
 ) -> None:
-    """Log a warning and sleep with exponential backoff before the next attempt."""
+    """Залогировать предупреждение и поспать с экспоненциальным backoff."""
     delay = REQUEST_INITIAL_DELAY_SECONDS * 2 ** (attempt - 1)
     _LOGGER.warning(
         "Transient failure on %s %s (%s), attempt %d/%d, retrying in %.1fs",

--- a/src/bot/internal_requests/tests/test_service.py
+++ b/src/bot/internal_requests/tests/test_service.py
@@ -26,7 +26,7 @@ def _patch_client(request_mock: AsyncMock):
 
 @patch.object(service.asyncio, "sleep", new=AsyncMock())
 class RequestRetryTests(IsolatedAsyncioTestCase):
-    """Retry behaviour of the shared internal HTTP client."""
+    """Поведение повторов общего внутреннего HTTP-клиента."""
 
     async def test_successful_request_returns_response(self):
         request = AsyncMock(return_value=_response(200))
@@ -101,7 +101,7 @@ class RequestRetryTests(IsolatedAsyncioTestCase):
 
 
 class IdempotencyWiringTests(IsolatedAsyncioTestCase):
-    """Each caller marks its request idempotent according to the endpoint."""
+    """Каждый вызывающий помечает свой запрос idempotent в соответствии с эндпоинтом."""
 
     @patch.object(service, "_request", new_callable=AsyncMock)
     async def test_create_answer_marks_request_idempotent(self, request_mock):
@@ -132,7 +132,7 @@ class IdempotencyWiringTests(IsolatedAsyncioTestCase):
 
 
 class SharedClientTests(IsolatedAsyncioTestCase):
-    """A single AsyncClient instance is reused across calls."""
+    """Единственный экземпляр AsyncClient переиспользуется между вызовами."""
 
     def setUp(self):
         service._client = None

--- a/src/bot/internal_requests/tests/test_service.py
+++ b/src/bot/internal_requests/tests/test_service.py
@@ -1,0 +1,151 @@
+import unittest
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+
+from internal_requests import service
+
+
+def _response(status_code: int) -> MagicMock:
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    response.raise_for_status = MagicMock()
+    if status_code >= 400:
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=response
+        )
+    return response
+
+
+def _patch_client(request_mock: AsyncMock):
+    client = MagicMock()
+    client.request = request_mock
+    return patch.object(service, "_get_client", return_value=client)
+
+
+@patch.object(service.asyncio, "sleep", new=AsyncMock())
+class RequestRetryTests(IsolatedAsyncioTestCase):
+    """Retry behaviour of the shared internal HTTP client."""
+
+    async def test_successful_request_returns_response(self):
+        request = AsyncMock(return_value=_response(200))
+        with _patch_client(request):
+            result = await service._get_request("users/1/")
+
+        self.assertEqual(result.status_code, 200)
+        request.assert_awaited_once()
+
+    async def test_retries_read_timeout_then_succeeds(self):
+        request = AsyncMock(side_effect=[httpx.ReadTimeout("slow"), _response(200)])
+        with _patch_client(request):
+            result = await service._get_request("users/1/")
+
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(request.await_count, 2)
+
+    async def test_retries_until_max_attempts_then_raises(self):
+        request = AsyncMock(side_effect=httpx.ConnectError("down"))
+        with _patch_client(request):
+            with self.assertRaises(httpx.ConnectError):
+                await service._get_request("users/1/")
+
+        self.assertEqual(request.await_count, service.REQUEST_MAX_ATTEMPTS)
+
+    async def test_retries_on_5xx_response(self):
+        request = AsyncMock(side_effect=[_response(503), _response(200)])
+        with _patch_client(request):
+            result = await service._get_request("users/1/")
+
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(request.await_count, 2)
+
+    async def test_does_not_retry_4xx_response(self):
+        request = AsyncMock(return_value=_response(404))
+        with _patch_client(request):
+            with self.assertRaises(httpx.HTTPStatusError):
+                await service._get_request("users/1/")
+
+        request.assert_awaited_once()
+
+    async def test_does_not_retry_non_idempotent_post(self):
+        request = AsyncMock(side_effect=httpx.ReadTimeout("slow"))
+        with _patch_client(request):
+            with self.assertRaises(httpx.ReadTimeout):
+                await service._post_request({"a": 1}, "problems/")
+
+        request.assert_awaited_once()
+
+    async def test_retries_idempotent_post(self):
+        request = AsyncMock(side_effect=[httpx.ReadTimeout("slow"), _response(201)])
+        with _patch_client(request):
+            result = await service._post_request({"a": 1}, "answers/", idempotent=True)
+
+        self.assertEqual(result.status_code, 201)
+        self.assertEqual(request.await_count, 2)
+
+    async def test_backoff_grows_exponentially_between_retries(self):
+        request = AsyncMock(
+            side_effect=[
+                httpx.ReadTimeout("slow"),
+                httpx.ReadTimeout("slow"),
+                _response(200),
+            ]
+        )
+        sleep = AsyncMock()
+        with _patch_client(request), patch.object(service.asyncio, "sleep", new=sleep):
+            result = await service._get_request("users/1/")
+
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual([call.args[0] for call in sleep.await_args_list], [1.0, 2.0])
+
+
+class IdempotencyWiringTests(IsolatedAsyncioTestCase):
+    """Each caller marks its request idempotent according to the endpoint."""
+
+    @patch.object(service, "_request", new_callable=AsyncMock)
+    async def test_create_answer_marks_request_idempotent(self, request_mock):
+        answer = service.Answer(telegram_id=1, task_number=5, number=1, content="a")
+        await service.create_answer(answer)
+
+        self.assertTrue(request_mock.await_args.kwargs["idempotent"])
+
+    @patch.object(service, "_request", new_callable=AsyncMock)
+    async def test_create_question_is_not_idempotent(self, request_mock):
+        problem = service.Problem(telegram_id=1, message="help")
+        await service.create_question_from_user(problem)
+
+        self.assertFalse(request_mock.await_args.kwargs.get("idempotent", False))
+
+    @patch.object(service, "_request", new_callable=AsyncMock)
+    async def test_update_user_info_marks_request_idempotent(self, request_mock):
+        request_mock.return_value = _response(200)
+        request_mock.return_value.json.return_value = {
+            "telegram_id": 1,
+            "telegram_username": "u",
+            "name": "Ann",
+            "surname": "Smith",
+        }
+        await service.update_user_info(1, {"name": "Ann"})
+
+        self.assertTrue(request_mock.await_args.kwargs["idempotent"])
+
+
+class SharedClientTests(IsolatedAsyncioTestCase):
+    """A single AsyncClient instance is reused across calls."""
+
+    def setUp(self):
+        service._client = None
+
+    def tearDown(self):
+        service._client = None
+
+    def test_get_client_returns_same_instance(self):
+        first = service._get_client()
+        second = service._get_client()
+
+        self.assertIs(first, second)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Проблема

Бот создавал новый `httpx.AsyncClient` на **каждый** внутренний запрос — без явного таймаута и без ретраев. Когда бэкенд отвечал на POST медленнее дефолтного read-timeout httpx (5 c), `confirm_saving_answer` падал **до** перехода к следующему заданию: ответ на стороне бэкенда уже сохранён, а пользователь видел ошибку и застревал.

Воспроизведено на проде 03.06.2026: пользователь на **Задании 5** отправил ответ, словил `httpx.ReadTimeout`, ответ сохранился (`is_done=true`), но кнопка перехода не пришла.

## Что изменено

- **Единый клиент.** Один лениво создаваемый `AsyncClient` переиспользуется всеми пятью хелперами (keep-alive пул) — вместо нового на каждый запрос.
- **Явный таймаут.** `httpx.Timeout(connect=5, read=15, write=10, pool=5)`; read-timeout переопределяется через env `INTERNAL_API_TIMEOUT` с безопасным парсингом (битое значение не роняет импорт).
- **Ретраи с backoff.** Все запросы идут через общий `_request()`: до 3 попыток на транзиентных ошибках (transport errors и 5xx), экспоненциальный backoff 1 c / 2 c, каждый повтор логируется на `WARNING` (виден в прод-мониторинге). 4xx и успешные ответы не ретраятся.
- **Ретрай с учётом идемпотентности.** Повтор включается per-call: GET ретраится всегда; не-GET — только при явном `idempotent=True`. `create_answer` и `update_user_info` идемпотентны (проверено по бэкенд-коду); `create_question_from_user` — нет (создаёт строку + шлёт ментору), поэтому не ретраится.
- **Зависимость.** `httpx` объявлен явной зависимостью (раньше шёл транзитивно через python-telegram-bot); версия `0.28.1` не изменилась.

## Тесты

Добавлено 12 юнит-тестов: успех, retry-then-success на `ReadTimeout`, отсутствие ретрая на 4xx, отсутствие ретрая на не-идемпотентном POST, ретрай на идемпотентном POST, ретрай на 5xx, исчерпание попыток, рост backoff (1.0 → 2.0), переиспользование общего клиента.

Прогон: `27 passed`, `flake8` и `isort` — чисто.
